### PR TITLE
Validate terraform security configuration

### DIFF
--- a/.github/workflows/iac-security-scan.yml
+++ b/.github/workflows/iac-security-scan.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  tfsec:
-    name: "tfsec Security Scan"
+  trivy-terraform:
+    name: "Trivy Terraform Security Scan"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,16 +23,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run tfsec
-        uses: aquasecurity/tfsec-sarif-action@v1.0.5
+      # Trivy now includes tfsec functionality for Terraform scanning
+      - name: Run Trivy for Terraform Security Scan
+        uses: aquasecurity/trivy-action@master
         with:
-          sarif_file: tfsec-results.sarif
+          scan-type: 'config'
+          scan-ref: 'infrastructure/'
+          format: 'sarif'
+          output: 'trivy-terraform-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'  # Don't fail the build, just report
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2
         if: always()
         with:
-          sarif_file: tfsec-results.sarif
+          sarif_file: trivy-terraform-results.sarif
 
   checkov:
     name: "Checkov Security Scan"

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -166,10 +166,16 @@ jobs:
           else
             echo "No terraform dir; skipping."
           fi
-      - name: tfsec
-        uses: aquasecurity/tfsec-sarif-action@v1.0.5
+      # Trivy now includes tfsec functionality for Terraform scanning
+      - name: Run Trivy for Terraform Security Scan
+        uses: aquasecurity/trivy-action@master
         with:
-          sarif_file: tfsec-results.sarif
+          scan-type: 'config'
+          scan-ref: 'infrastructure/'
+          format: 'sarif'
+          output: 'trivy-terraform-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+          exit-code: '0'  # Don't fail the build, just report
       - name: checkov
         uses: bridgecrewio/checkov-action@v12
         with:
@@ -182,4 +188,4 @@ jobs:
         if: always()
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: tfsec-results.sarif
+          sarif_file: trivy-terraform-results.sarif


### PR DESCRIPTION
Migrate Terraform security scanning in GitHub Actions from `tfsec-sarif-action` to `Trivy` to fix workflow failures and use the recommended tool.

The `aquasecurity/tfsec-sarif-action@v1.0.5` was failing because this specific version does not exist. `tfsec` has been integrated into `Trivy`, making `Trivy` the current and actively maintained solution for Terraform security scanning.

---
<a href="https://cursor.com/background-agent?bcId=bc-669b7262-e68d-400f-88fe-03e423ff40f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-669b7262-e68d-400f-88fe-03e423ff40f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

