### PR TITLE
Fix ci/cd test setup and database connectivity

### DIFF
--- a/scripts/ci-test-setup.js
+++ b/scripts/ci-test-setup.js
@@ -185,24 +185,50 @@ try {
 try {
   log('🔍 Verifying test setup...');
 
-  // Check if Prisma client was generated
-  const prismaClientPath = path.join(
+  // Determine Prisma client output from schema and check common workspace locations
+  const authServicePath = path.join(
     __dirname,
     '..',
     'backend',
     'services',
-    'auth-service',
-    'node_modules',
-    '.prisma',
-    'client'
+    'auth-service'
   );
+  const schemaPath = path.join(authServicePath, 'prisma', 'schema.prisma');
 
-  if (!fs.existsSync(prismaClientPath)) {
-    error(`Prisma client not found at: ${prismaClientPath}`);
+  let schemaOutputPathAbs = null;
+  try {
+    const schemaContent = fs.readFileSync(schemaPath, 'utf8');
+    const outputMatch = schemaContent.match(/generator\s+client\s*\{[\s\S]*?output\s*=\s*"([^"]+)"/);
+    if (outputMatch && outputMatch[1]) {
+      schemaOutputPathAbs = path.resolve(path.dirname(schemaPath), outputMatch[1]);
+    }
+  } catch (schemaErr) {
+    warning(`Could not read Prisma schema output path: ${schemaErr.message}`);
+  }
+
+  const candidatePaths = [
+    // Explicit path from schema if available
+    ...(schemaOutputPathAbs ? [schemaOutputPathAbs] : []),
+    // Service-local node_modules
+    path.join(authServicePath, 'node_modules', '.prisma', 'client'),
+    // Workspace root node_modules
+    path.join(__dirname, '..', 'node_modules', '.prisma', 'client'),
+    // Backend package node_modules
+    path.join(__dirname, '..', 'backend', 'node_modules', '.prisma', 'client'),
+    // Backend/services package node_modules (relative to schema output ../../../)
+    path.join(__dirname, '..', 'backend', 'services', 'node_modules', '.prisma', 'client'),
+  ];
+
+  const verifiedPath = candidatePaths.find((p) => fs.existsSync(p));
+
+  if (!verifiedPath) {
+    error(
+      `Prisma client not found. Checked:\n- ${candidatePaths.join('\n- ')}`
+    );
     process.exit(1);
   }
 
-  success('Prisma client verified');
+  success(`Prisma client verified at: ${verifiedPath}`);
 
   // Note: We don't test database connection here since it's expected to fail
   // in local development without a running test database


### PR DESCRIPTION
Enhance Prisma client verification in CI setup script to correctly locate the client in pnpm workspaces, resolving CI failures.

The previous CI setup failed because it only checked a service-local path for the Prisma client, which was incorrect for pnpm workspaces where the client might be hoisted or generated to a different location. This PR updates the `ci-test-setup.js` script to dynamically read the Prisma client's output path from `schema.prisma` and check multiple common pnpm workspace locations, ensuring the client is found and allowing the CI to proceed with tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-8915234d-aeeb-4099-a699-3cda1a6bd72f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8915234d-aeeb-4099-a699-3cda1a6bd72f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

